### PR TITLE
Support for Pulsar 1.5

### DIFF
--- a/src/output/borders.pr
+++ b/src/output/borders.pr
@@ -26,8 +26,8 @@
 }
 
 *}
-{[ const allTokens = @ds.allTokens() /]}
-{[ const allGroups = @ds.allTokenGroups() /]}
-{[ const rootGroup = @ds.tokenGroupTreeByType("Border") /]}
-{[ const sdTree = @js.generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
-{{ @js.objectToPrettyJson(sdTree) }}
+{[ const allTokens = ds.allTokens() /]}
+{[ const allGroups = ds.allTokenGroups() /]}
+{[ const rootGroup = ds.tokenGroupTreeByType("Border") /]}
+{[ const sdTree = generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
+{{ objectToPrettyJson(sdTree) }}

--- a/src/output/colors.pr
+++ b/src/output/colors.pr
@@ -12,8 +12,8 @@
 }
 
 *}
-{[ const allTokens = @ds.allTokens() /]}
-{[ const allGroups = @ds.allTokenGroups() /]}
-{[ const rootGroup = @ds.tokenGroupTreeByType("Color") /]}
-{[ const sdTree = @js.generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
-{{ @js.objectToPrettyJson(sdTree) }}
+{[ const allTokens = ds.allTokens() /]}
+{[ const allGroups = ds.allTokenGroups() /]}
+{[ const rootGroup = ds.tokenGroupTreeByType("Color") /]}
+{[ const sdTree = generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
+{{ objectToPrettyJson(sdTree) }}

--- a/src/output/fonts.pr
+++ b/src/output/fonts.pr
@@ -21,8 +21,8 @@
 }
 
 *}
-{[ const allTokens = @ds.allTokens() /]}
-{[ const allGroups = @ds.allTokenGroups() /]}
-{[ const rootGroup = @ds.tokenGroupTreeByType("Font") /]}
-{[ const sdTree = @js.generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
-{{ @js.objectToPrettyJson(sdTree) }}
+{[ const allTokens = ds.allTokens() /]}
+{[ const allGroups = ds.allTokenGroups() /]}
+{[ const rootGroup = ds.tokenGroupTreeByType("Font") /]}
+{[ const sdTree = generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
+{{ objectToPrettyJson(sdTree) }}

--- a/src/output/gradients.pr
+++ b/src/output/gradients.pr
@@ -50,8 +50,8 @@
 }
 
 *}
-{[ const allTokens = @ds.allTokens() /]}
-{[ const allGroups = @ds.allTokenGroups() /]}
-{[ const rootGroup = @ds.tokenGroupTreeByType("Gradient") /]}
-{[ const sdTree = @js.generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
-{{ @js.objectToPrettyJson(sdTree) }}
+{[ const allTokens = ds.allTokens() /]}
+{[ const allGroups = ds.allTokenGroups() /]}
+{[ const rootGroup = ds.tokenGroupTreeByType("Gradient") /]}
+{[ const sdTree = generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
+{{ objectToPrettyJson(sdTree) }}

--- a/src/output/measures.pr
+++ b/src/output/measures.pr
@@ -21,8 +21,8 @@
 }
 
 *}
-{[ const allTokens = @ds.allTokens() /]}
-{[ const allGroups = @ds.allTokenGroups() /]}
-{[ const rootGroup = @ds.tokenGroupTreeByType("Measure") /]}
-{[ const sdTree = @js.generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
-{{ @js.objectToPrettyJson(sdTree) }}
+{[ const allTokens = ds.allTokens() /]}
+{[ const allGroups = ds.allTokenGroups() /]}
+{[ const rootGroup = ds.tokenGroupTreeByType("Measure") /]}
+{[ const sdTree = generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
+{{ objectToPrettyJson(sdTree) }}

--- a/src/output/radii.pr
+++ b/src/output/radii.pr
@@ -38,8 +38,8 @@
 }
 
 *}
-{[ const allTokens = @ds.allTokens() /]}
-{[ const allGroups = @ds.allTokenGroups() /]}
-{[ const rootGroup = @ds.tokenGroupTreeByType("Radius") /]}
-{[ const sdTree = @js.generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
-{{ @js.objectToPrettyJson(sdTree) }}
+{[ const allTokens = ds.allTokens() /]}
+{[ const allGroups = ds.allTokenGroups() /]}
+{[ const rootGroup = ds.tokenGroupTreeByType("Radius") /]}
+{[ const sdTree = generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
+{{ objectToPrettyJson(sdTree) }}

--- a/src/output/shadows.pr
+++ b/src/output/shadows.pr
@@ -37,8 +37,8 @@
 }
 
 *}
-{[ const allTokens = @ds.allTokens() /]}
-{[ const allGroups = @ds.allTokenGroups() /]}
-{[ const rootGroup = @ds.tokenGroupTreeByType("Shadow") /]}
-{[ const sdTree = @js.generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
-{{ @js.objectToPrettyJson(sdTree) }}
+{[ const allTokens = ds.allTokens() /]}
+{[ const allGroups = ds.allTokenGroups() /]}
+{[ const rootGroup = ds.tokenGroupTreeByType("Shadow") /]}
+{[ const sdTree = generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
+{{ objectToPrettyJson(sdTree) }}

--- a/src/output/text.pr
+++ b/src/output/text.pr
@@ -12,8 +12,8 @@
 }
 
 *}
-{[ const allTokens = @ds.allTokens() /]}
-{[ const allGroups = @ds.allTokenGroups() /]}
-{[ const rootGroup = @ds.tokenGroupTreeByType("Text") /]}
-{[ const sdTree = @js.generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
-{{ @js.objectToPrettyJson(sdTree) }}
+{[ const allTokens = ds.allTokens() /]}
+{[ const allGroups = ds.allTokenGroups() /]}
+{[ const rootGroup = ds.tokenGroupTreeByType("Text") /]}
+{[ const sdTree = generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
+{{ objectToPrettyJson(sdTree) }}

--- a/src/output/typography.pr
+++ b/src/output/typography.pr
@@ -50,8 +50,8 @@
 }
 
 *}
-{[ const allTokens = @ds.allTokens() /]}
-{[ const allGroups = @ds.allTokenGroups() /]}
-{[ const rootGroup = @ds.tokenGroupTreeByType("Typography") /]}
-{[ const sdTree = @js.generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
-{{ @js.objectToPrettyJson(sdTree) }}
+{[ const allTokens = ds.allTokens() /]}
+{[ const allGroups = ds.allTokenGroups() /]}
+{[ const rootGroup = ds.tokenGroupTreeByType("Typography") /]}
+{[ const sdTree = generateStyleDictionaryTree(rootGroup, allTokens, allGroups) /]}
+{{ objectToPrettyJson(sdTree) }}


### PR DESCRIPTION
This PR adds support for Pulsar 1.5

- All javascript calls now treated as top-level functions (no more `@js.` needed and will throw error if used) so all are reworked
- DS accessors are now proper methods on top-level `ds` object, so everything was reworked for this and autocomplete now properly works for those as well
- All ds methods are now actual methods, and can't have extra `.` inside it, so that was removed (for example, `@ds.fonts.isItalic` is now actually `ds.isFontItalic()`)
- Expressions have been simplified and syntax reworked to be aligned with new Pulsar, which follows JS syntax closely now
- Complex expressions inside flows must be surrounded with `()`, but expressions inside `{{ }}` don't need this, so reworked as well
- Added shorthands and object support, so you can use `{}` and `[]` to create empty objects and arrays, and all methods used previously to init etc. were removed
- `self` is `this` to align with javascript, and `self` is no longer available as global property

- Version of exporter bumped to next minor


Note for reviewer:
This PR CAN'T be merged and exporter run before Pulsar is merged to your environments, please don't merge it yourself.