### PR TITLE
Strip line breaks from descriptions (comments)

### DIFF
--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -427,7 +427,7 @@ function tokenWrapper(token: Token, value: any) {
   return {
     value: value,
     type: typeLabel(token.tokenType),
-    comment: token.description.length > 0 ? token.description : undefined,
+    comment: token.description.length > 0 ? token.description.replace(/\r?\n|\r/g, ' ') : undefined, // Use the description as a comment, but replace line breaks with spaces. Otherwise, the output will be broken until https://github.com/amzn/style-dictionary/pull/953 is fixed
   }
 }
 


### PR DESCRIPTION
Currently, multi-line comments (such as having `\n`) will cause the export to break due to a Style Dictionary issue (https://github.com/amzn/style-dictionary/pull/953). Until that is fixed, multi-line comments will break the output.

This simple PR just replaces line breaks (`\n` and `\r`) with a single space.

## Example input (exported from Supernova)
```
"color": {
      "gray-100": {
        "value": "#f3f6f8ff",
        "type": "color",
        "comment": "Previous style:\nGray/White"
      },
```

The comment `\nGray/White` is where the problem is.

## Before
![image](https://github.com/Supernova-Studio/exporter-style-dictionary/assets/11964962/65028326-4a35-4ef9-b62b-e23c34ba4d37)

The string `Gray/White` gets put on its own line, in an invalid way.

## After
![image](https://github.com/Supernova-Studio/exporter-style-dictionary/assets/11964962/e3c42b92-d100-4804-a00e-6d51d9b19be5)

The line breaks get replaced with a space and the comment is fixed, creating valid output.